### PR TITLE
Use Hackage-friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,3 +4,4 @@ packages:
 extra-deps: []
 flags: {}
 extra-package-dbs: []
+pvp-bounds: both

--- a/transient.cabal
+++ b/transient.cabal
@@ -32,7 +32,7 @@ data-dir: ""
 library
     -- Note: `stack sdist/upload` will add missing bounds (via "pvp-bounds: both") in `build-depends`
     -- support GHC 7.10.3 and later; lower bounds below denote GHC 7.10.3's bundled versions
-    build-depends:     base          >= 4.8.2  &&  < 5
+    build-depends:     base          >= 4.8.1  &&  < 5
                      , containers    >= 0.5.6
                      , transformers  >= 0.4.2
                      , time          >= 1.5

--- a/transient.cabal
+++ b/transient.cabal
@@ -30,16 +30,19 @@ data-dir: ""
 
 
 library
-    build-depends:     base          > 4  &&  < 5
-                     , containers
-                     , mtl
-                     , transformers
-                     , stm
-                     , time
-                     , directory
-                     , random
-                     , bytestring
+    -- Note: `stack sdist/upload` will add missing bounds (via "pvp-bounds: both") in `build-depends`
+    -- support GHC 7.10.3 and later; lower bounds below denote GHC 7.10.3's bundled versions
+    build-depends:     base          >= 4.8.2  &&  < 5
+                     , containers    >= 0.5.6
+                     , transformers  >= 0.4.2
+                     , time          >= 1.5
+                     , directory     >= 1.2.2
+                     , bytestring    >= 0.10.6
 
+                     -- libraries not bundled w/ GHC
+                     , mtl
+                     , stm
+                     , random
 
     exposed-modules: Transient.Backtrack
                      Transient.Base


### PR DESCRIPTION
This makes sure that the meta-data contains more accurate meta-data
for the cabal solver to work with, and helps reducing the risk
of install-plan bitrotting on Hackage.

See also
https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds