### PR TITLE
First pass of refactor

### DIFF
--- a/transient.cabal
+++ b/transient.cabal
@@ -1,33 +1,25 @@
 name: transient
-
-
 version: 0.5.4
-
-
 author: Alberto G. Corona
-
 extra-source-files:
     ChangeLog.md README.md
-
 maintainer: agocorona@gmail.com
-
 cabal-version: >=1.10
-
 build-type: Simple
-
 license: MIT
 license-file: LICENSE
-
 homepage: http://www.fpcomplete.com/user/agocorona
 bug-reports: https://github.com/agocorona/transient/issues
-
 synopsis: composing programs with multithreading, events and distributed computing
 description: See <http://github.com/agocorona/transient>
              In this release distributed primitives have been moved to the transient-universe package, and web primitives have been moved to the ghcjs-hplay package.
 category: Control
-
 data-dir: ""
 
+flag debug
+  description:  Enable debugging outputs
+  default:      False
+  manual:       True
 
 library
     -- Note: `stack sdist/upload` will add missing bounds (via "pvp-bounds: both") in `build-depends`
@@ -56,6 +48,8 @@ library
     exposed: True
     default-language: Haskell2010
     hs-source-dirs: src .
+    if flag(debug)
+       cpp-options: -DDEBUG
 
 source-repository head
     type: git


### PR DESCRIPTION
1. Changed the `Transient` monad to a `newtype` to avoid boxing overhead.

2. Added DEBUG CPP constant and debug flag to enable usage of `(!>)`
  - To build with debugging enabled,
    ```
    stack build --flag transient:debug
    ```

3. Used Record extensions to make the code clearer wherever possible.

4. Replaced the `Loggable a` class with a constraint type synonym.
  - Equivalent to what's required an removes one layer of dictionary overhead.

5. Made spacing/identation consistent as much as possible.

6. Collected all the `Transient` instances in once place so that they're easier to find.

I've only done the top section of `Transient.Internals`. As  I get more time I'll do the rest of the module as well.