### PR TITLE
Add transformers support to transient

### DIFF
--- a/src/Transient/Base.hs
+++ b/src/Transient/Base.hs
@@ -249,7 +249,7 @@ TransIO(..), TransientIO
 ,parallel, async, waitEvents, sample, spawn, react
 
 -- * State management
-,setData, getSData, getData, delData, modifyData, try, setState, getState, delState, modifyState
+,setSData, setData, getSData, getData, delData, modifyData, try, setState, getState, delState, modifyState
 
 -- * Thread management
 , threads,addThreads, freeThreads, hookedThreads,oneThread, killChilds

--- a/src/Transient/EVars.hs
+++ b/src/Transient/EVars.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE PatternSynonyms    #-}
+
 module Transient.EVars where
 
 import Transient.Base
-import Transient.Internals(runTransState,onNothing, EventF(..), killChildren)
+import Transient.Internals (pattern Transient, runTransState,onNothing, EventF(..), killChildren)
 import qualified Data.Map as M
 import Data.Typeable
 

--- a/transient.cabal
+++ b/transient.cabal
@@ -32,9 +32,12 @@ library
                      , bytestring    >= 0.10.6
 
                      -- libraries not bundled w/ GHC
+                     , lifted-base
+                     , monad-control
                      , mtl
                      , stm
                      , random
+                     , transformers-base
 
     exposed-modules: Transient.Backtrack
                      Transient.Base


### PR DESCRIPTION
Transient now implements a transformer monad named `AsyncT` that provides
composition of asynchronous effects on top of any monad that implements
`MonadIO`. It can be used anywhere in a transformer stack. I might add a 
few more commits with minor changes (e.g. exporting the transformer interface,
renaming of fields etc.), but this commit captures the essence of the change.

`TransIO` is now implemented as `AsyncT IO`.  There is no change in
external APIs except that now you have to use a new `setSData` API in place
of `setData` inside TransIO, just like `getSData` for get operation. This will
require a version bump.

The change consists of largely signature changes. I have tried to
keep the changes to a minimum in this commit to help in review. The
significant changes are:

1) Add the transformer base monad as an existential variable `EventF`
2) A few more `unsafeCoerce`s for the continuation type conversions
3) lowering of monad computations into IO to facilitate `forkIO` for new
   event creation. This requires `monad-control` and `lifted-base`.